### PR TITLE
Fix emd build for newer PyTorch versions 

### DIFF
--- a/loss/cuda/emd_torch/pkg/include/cuda_helper.h
+++ b/loss/cuda/emd_torch/pkg/include/cuda_helper.h
@@ -1,6 +1,10 @@
 #ifndef CUDA_HELPER_H_
 #define CUDA_HELPER_H_
 
+#ifndef AT_CHECK
+#define AT_CHECK TORCH_CHECK
+#endif
+
 #define CUDA_CHECK(err) \
 	if (cudaSuccess != err) \
 	{ \


### PR DESCRIPTION
AT_CHECK has been deprecated in torch 1.5
https://github.com/pytorch/pytorch/issues/36581

This results in build failure of the emd package with:
pkg/include\emd.h(32): error C3861: 'AT_CHECK': identifier not found
pkg/include\emd.h(33): error C3861: 'AT_CHECK': identifier not found
pkg/include\emd.h(43): error C3861: 'AT_CHECK': identifier not found
pkg/include\emd.h(44): error C3861: 'AT_CHECK': identifier not found
pkg/include\emd.h(45): error C3861: 'AT_CHECK': identifier not found